### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The lower bound, upper bound and the step argument are all optional.
 The default value for the lower bound is 0.
 
 ```
-const arr = [1,  2, 3, 4];
+const arr = [1, 2, 3, 4];
 arr[:3:1];
 // → [1, 2, 3]
 ```
@@ -76,14 +76,14 @@ arr[:3:1];
 The default value for the upper bound is the length of the object.
 
 ```
-const arr = [1,  2, 3, 4];
+const arr = [1, 2, 3, 4];
 arr[1::1];
 // → [2, 3, 4]
 ```
 
 The default value for the step argument is 1.
 ```
-const arr = [1,  2, 3, 4];
+const arr = [1, 2, 3, 4];
 
 arr[1:];
 // → [2, 3, 4]


### PR DESCRIPTION
commas should be followed by one space