### PR TITLE
Changing "Golang" to "Go"

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ arr[1...3];
 // → [2, 3]
 ```
 
-### Golang
+### Go
 
-Golang offers [slices](https://gobyexample.com/slices):
+Go offers [slices](https://gobyexample.com/slices):
 
 ```go
 arr := []int{1,2,3,4};


### PR DESCRIPTION
This PR is a follow-up to #11.

It changes references to the "Go" programming language which erroneously refer to the language with the term "Golang".

"Golang" is the domain name of the Go language and is used in areas where there is lack of context (such as generic searches), since the name "Go" is otherwise too generic.